### PR TITLE
feat: add prysmctl and client-stats incl install script for service

### DIFF
--- a/client-stats.service
+++ b/client-stats.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Prysm Client Stats
+Wants=network-online.target
+After=network-online.target
+Requires=validator.service
+
+[Service]
+Type=simple
+User=prysm
+Group=prysm
+Restart=on-failure
+RestartSec=3
+KillSignal=SIGINT
+TimeoutStopSec=900
+ExecStart=/usr/local/bin/client-stats \
+  --beacon-node-metrics-url=http://localhost:8080/metrics \
+  --validator-metrics-url=http://localhost:8081/metrics \
+  --clientstats-api-url=https://beaconcha.in/api/v1/stats/<YOUR_BEACONCHA.IN_API-KEY>/<YOUR_VALIDATOR_NAME> \
+  --scrape-interval 3m
+
+[Install]
+WantedBy=multi-user.target

--- a/install_client_stats_service.sh
+++ b/install_client_stats_service.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Copy the service file to systemd directory
+sudo cp client-stats.service /etc/systemd/system/
+
+# Reload systemd to recognize the new service
+sudo systemctl daemon-reload
+
+# Enable the service to start on boot
+sudo systemctl enable client-stats
+
+# Start the service
+sudo systemctl start client-stats
+
+echo "Prysm client-stats service has been installed and started." 

--- a/update_consensus.sh
+++ b/update_consensus.sh
@@ -159,16 +159,24 @@ function updateClient(){
 		_platform=$(echo ${_platform} | tr '[:upper:]' '[:lower:]')
 		file_beacon=beacon-chain-${prysm_version}-${_platform}-${_arch}
 		file_validator=validator-${prysm_version}-${_platform}-${_arch}
+		file_client_stats=client-stats-${prysm_version}-${_platform}-${_arch}
+		file_prysmctl=prysmctl-${prysm_version}-${_platform}-${_arch}
 		curl -f -L "https://prysmaticlabs.com/releases/${file_beacon}" -o beacon-chain
 		curl -f -L "https://prysmaticlabs.com/releases/${file_validator}" -o validator
-		chmod +x beacon-chain validator
+		curl -f -L "https://prysmaticlabs.com/releases/${file_client_stats}" -o client-stats
+		curl -f -L "https://prysmaticlabs.com/releases/${file_prysmctl}" -o prysmctl
+		chmod +x beacon-chain validator client-stats prysmctl
 		test -f /etc/systemd/system/consensus.service && sudo systemctl stop consensus
 		test -f /etc/systemd/system/validator.service && sudo service validator stop
+		test -f /etc/systemd/system/prysm-stats.service && sudo systemctl stop client-stats
 		sudo rm /usr/local/bin/beacon-chain
 		sudo rm /usr/local/bin/validator
-		sudo mv beacon-chain validator /usr/local/bin
-		test -f /etc/systemd/system/consensus.service && sudo systemctl start consensus
-		test -f /etc/systemd/system/validator.service && sudo service validator start
+		sudo rm /usr/local/bin/client-stats
+		sudo rm /usr/local/bin/prysmctl
+		sudo mv beacon-chain validator client-stats prysmctl /usr/local/bin
+        test -f /etc/systemd/system/consensus.service && sudo systemctl start consensus
+        test -f /etc/systemd/system/validator.service && sudo systemctl start validator
+		test -f /etc/systemd/system/prysm-stats.service && sudo systemctl start client-stats
 	    ;;
 	  esac
 }


### PR DESCRIPTION
## feat(prysm): add prysmctl & client‑stats binaries + systemd service

### Summary
This PR extends the Prysm update flow in `update_consensus.sh` to also download and install the `prysmctl` and `client‑stats` binaries, and to stop/restart a new `client‑stats` systemd service alongside the existing consensus and validator services. It also adds:

- **`client-stats.service`** – a systemd unit for running the Prysm client‑stats exporter  
- **`install_client_stats_service.sh`** – an install script to deploy & enable that service  

### What’s Changed

1. **`update_consensus.sh`** (Prysm case)
   - Added two new download targets:
     ```bash
     file_client_stats=client-stats-${prysm_version}-${_platform}-${_arch}
     file_prysmctl=prysmctl-${prysm_version}-${_platform}-${_arch}
     ```
   - Download both with `curl -f -L …` and make them executable:
     ```bash
     curl -f -L "https://prysmaticlabs.com/releases/${file_client_stats}" -o client-stats
     curl -f -L "https://prysmaticlabs.com/releases/${file_prysmctl}"     -o prysmctl
     chmod +x client-stats prysmctl
     ```
   - Stop/start the `client‑stats` service in line with consensus & validator:
     ```bash
     sudo systemctl stop client-stats   # before removal/install
     …
     sudo systemctl start client-stats  # after moving binaries
     ```

2. **New file: `client-stats.service`**
   ```ini
   [Unit]
   Description=Prysm Client Stats
   Wants=network-online.target
   After=network-online.target
   Requires=validator.service

   [Service]
   Type=simple
   User=prysm
   Group=prysm
   Restart=on-failure
   RestartSec=3
   KillSignal=SIGINT
   TimeoutStopSec=900
   ExecStart=/usr/local/bin/client-stats \
     --beacon-node-metrics-url=http://localhost:8080/metrics \
     --validator-metrics-url=http://localhost:8081/metrics \
     --clientstats-api-url=https://beaconcha.in/api/v1/stats/<YOUR_BEACONCHA.IN_API-KEY>/<YOUR_VALIDATOR_NAME> \
     --scrape-interval 3m

   [Install]
   WantedBy=multi-user.target


3. **New file: `install_client_stats_service.sh`**
```bash
#!/bin/bash

# Copy the service file to systemd directory
sudo cp client-stats.service /etc/systemd/system/

# Reload systemd to recognize the new service
sudo systemctl daemon-reload

# Enable the service to start on boot
sudo systemctl enable client-stats

# Start the service
sudo systemctl start client-stats

echo "Prysm client-stats service has been installed and started."
```

### Testing & Verification
1. Run the update script for Prysm:
```bash
./update_consensus.sh Prysm
```

2. Confirm the new binaries exist and are executable:
```bash
ls -l /usr/local/bin/{prysmctl,client-stats}
```

3. Verify the client-stats service status:
```bash
sudo systemctl status client-stats
```
- Service should be **loaded, enabled**, and **running** without errors.

4. (Optional) Tail the logs to confirm metrics scraping and API uploads:
```bash
sudo journalctl -u client-stats -f
```