### PR TITLE
Update monitor ports in client-stats.service

### DIFF
--- a/client-stats.service
+++ b/client-stats.service
@@ -13,8 +13,8 @@ RestartSec=3
 KillSignal=SIGINT
 TimeoutStopSec=900
 ExecStart=/usr/local/bin/client-stats \
-  --beacon-node-metrics-url=http://localhost:8080/metrics \
-  --validator-metrics-url=http://localhost:8081/metrics \
+  --beacon-node-metrics-url=http://localhost:8008/metrics \
+  --validator-metrics-url=http://localhost:8009/metrics \
   --clientstats-api-url=https://beaconcha.in/api/v1/stats/<YOUR_BEACONCHA.IN_API-KEY>/<YOUR_VALIDATOR_NAME> \
   --scrape-interval 3m
 


### PR DESCRIPTION
This PR updates the monitor ports in client-stats.service to align with other consensus layer clients:

- Changed beacon node metrics URL port from 8080 to 8008
- Changed validator metrics URL port from 8081 to 8009

These changes make Prysm's port configuration consistent with other consensus layer clients, as mentioned in the EthPillar documentation: "prysm's defaults are not consistent with other CLs."

The update ensures that the client stats service correctly connects to the standardized monitoring endpoints as documented in the Ethpillar guide metioned [here for beacon node](https://www.coincashew.com/coins/overview-eth/testnet-hoodi/step-4-installing-consensus-client/prysm) and [here for validator](https://www.coincashew.com/coins/overview-eth/testnet-hoodi/step-5-installing-validator/installing-validator/prysm).