### PR TITLE
Remove client-stats from update_consensus.sh script

### DIFF
--- a/update_consensus.sh
+++ b/update_consensus.sh
@@ -162,24 +162,19 @@ function updateClient(){
 		_platform=$(echo ${_platform} | tr '[:upper:]' '[:lower:]')
 		file_beacon=beacon-chain-${prysm_version}-${_platform}-${_arch}
 		file_validator=validator-${prysm_version}-${_platform}-${_arch}
-		file_client_stats=client-stats-${prysm_version}-${_platform}-${_arch}
 		file_prysmctl=prysmctl-${prysm_version}-${_platform}-${_arch}
 		curl -f -L "https://prysmaticlabs.com/releases/${file_beacon}" -o beacon-chain
 		curl -f -L "https://prysmaticlabs.com/releases/${file_validator}" -o validator
-		curl -f -L "https://prysmaticlabs.com/releases/${file_client_stats}" -o client-stats
 		curl -f -L "https://prysmaticlabs.com/releases/${file_prysmctl}" -o prysmctl
-		chmod +x beacon-chain validator client-stats prysmctl
+		chmod +x beacon-chain validator prysmctl
 		test -f /etc/systemd/system/consensus.service && sudo systemctl stop consensus
 		test -f /etc/systemd/system/validator.service && sudo service validator stop
-		test -f /etc/systemd/system/client-stats.service && sudo systemctl stop client-stats
 		sudo rm /usr/local/bin/beacon-chain
 		sudo rm /usr/local/bin/validator
-		sudo rm /usr/local/bin/client-stats
 		sudo rm /usr/local/bin/prysmctl
-		sudo mv beacon-chain validator client-stats prysmctl /usr/local/bin
-        test -f /etc/systemd/system/consensus.service && sudo systemctl start consensus
-        test -f /etc/systemd/system/validator.service && sudo systemctl start validator
-		test -f /etc/systemd/system/client-stats.service && sudo systemctl start client-stats
+		sudo mv beacon-chain validator prysmctl /usr/local/bin
+		test -f /etc/systemd/system/consensus.service && sudo systemctl start consensus
+		test -f /etc/systemd/system/validator.service && sudo systemctl start validator
 	    ;;
 	  esac
 }


### PR DESCRIPTION
Remove client stats from update_consensus.sh script as it's now handled as an optional plugin feature.