### PR TITLE
Fix/env override handling

### DIFF
--- a/plugins/node-checker/run.sh
+++ b/plugins/node-checker/run.sh
@@ -20,8 +20,22 @@ EL_RPC_ENDPOINT="localhost:8545"
 if [[ -f "$SOURCE_DIR"/../../.env.overrides ]]; then
     # shellcheck source=/dev/null
     source "$SOURCE_DIR"/../../.env.overrides
-    API_BN_ENDPOINT="http://${CL_IP_ADDRESS}:${CL_REST_PORT}"
-    EL_RPC_ENDPOINT="${EL_IP_ADDRESS}:${EL_RPC_PORT}"
+    
+    # Handle consensus layer endpoint overrides
+    if [[ -n "${CL_IP_ADDRESS:-}" || -n "${CL_REST_PORT:-}" ]]; then
+        # Use default values if not overridden
+        local_cl_ip="${CL_IP_ADDRESS:-localhost}"
+        local_cl_port="${CL_REST_PORT:-5052}"
+        API_BN_ENDPOINT="http://${local_cl_ip}:${local_cl_port}"
+    fi
+    
+    # Handle execution layer endpoint overrides
+    if [[ -n "${EL_IP_ADDRESS:-}" || -n "${EL_RPC_PORT:-}" ]]; then
+        # Use default values if not overridden
+        local_el_ip="${EL_IP_ADDRESS:-localhost}"
+        local_el_port="${EL_RPC_PORT:-8545}"
+        EL_RPC_ENDPOINT="${local_el_ip}:${local_el_port}"
+    fi
 fi
 
 # Thresholds

--- a/plugins/node-checker/run.sh
+++ b/plugins/node-checker/run.sh
@@ -14,7 +14,7 @@ p2p_ports=("9000" "30303")
 p2p_processes=("geth" "besu" "teku" "lighthouse" "prysm" "nimbus" "erigon" "nethermind" "reth" "mev-boost")
 services=("consensus" "execution" "validator" "mevboost")
 API_BN_ENDPOINT="http://localhost:5052"
-EL_RPC_ENDPOINT="localhost:8545"
+EL_RPC_ENDPOINT="http://localhost:8545"
 
 # Load environment variables overrides
 if [[ -f "$SOURCE_DIR"/../../.env.overrides ]]; then
@@ -34,7 +34,7 @@ if [[ -f "$SOURCE_DIR"/../../.env.overrides ]]; then
         # Use default values if not overridden
         local_el_ip="${EL_IP_ADDRESS:-localhost}"
         local_el_port="${EL_RPC_PORT:-8545}"
-        EL_RPC_ENDPOINT="${local_el_ip}:${local_el_port}"
+        EL_RPC_ENDPOINT="http://${local_el_ip}:${local_el_port}"
     fi
 fi
 


### PR DESCRIPTION
## Description
This PR improves the handling of environment variable overrides in the node checker script and ensures consistent URL formatting.

## Changes
1. Environment Variable Override Improvements:
   - Modified environment variable override logic to handle individual variable overrides
   - Added default values for unset variables
   - Improved error handling for missing variables
   - Now supports partial overrides of either IP or port for both endpoints

2. URL Format Consistency:
   - Added `http://` prefix to `EL_RPC_ENDPOINT` default value
   - Added `http://` prefix to overridden `EL_RPC_ENDPOINT` value
   - Ensures consistent URL formatting across both endpoints

## Testing
The changes allow for more flexible configuration in `.env.overrides`:

### Environment Variable Overrides
- Can override just CL_REST_PORT while keeping default localhost
- Can override just CL_IP_ADDRESS while keeping default port
- Can override just EL_RPC_PORT while keeping default localhost
- Can override just EL_IP_ADDRESS while keeping default port
- Can override both variables for either endpoint
- Can override none of the variables

### URL Format
- Both endpoints now consistently use `http://` prefix
- Default values: 
  - `API_BN_ENDPOINT="http://localhost:5052"`
  - `EL_RPC_ENDPOINT="http://localhost:8545"`
- Overridden values maintain the `http://` prefix

## Example .env.overrides Configurations
```bash
# Override just the consensus layer port
CL_REST_PORT=3500

# Override just the execution layer IP
EL_IP_ADDRESS=192.168.1.100

# Override both consensus layer variables
CL_IP_ADDRESS=192.168.1.100
CL_REST_PORT=3500

# Override both execution layer variables
EL_IP_ADDRESS=192.168.1.100
EL_RPC_PORT=8545
```

## Related Issues
