### PR TITLE
feat: Improve service status display with emojis and better formatting

### DIFF
--- a/plugins/node-checker/run.sh
+++ b/plugins/node-checker/run.sh
@@ -493,27 +493,32 @@ check_systemd_services() {
     for service in "${services[@]}"; do
         service_installed=0
         ((total_checks+=3))  # Three checks per service (installed + active + enabled)
+        
+        # Print service header
+        echo -e "\n${BLUE}${BOLD}📦 ${service^} Service${NC}"
+        echo -e "${BLUE}${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+        
         # Check installation
         if [ -f /etc/systemd/system/"${service}".service ]; then
             service_installed=1
-            echo -e "${GREEN}[PASS] ${service} is installed${NC}"
+            echo -e "${GREEN}[PASS] 📥 Installed${NC}"
         else
-            echo -e "${BLUE}${BOLD}[INFO] ${service} not installed${NC}"
+            echo -e "${BLUE}${BOLD}[INFO] ❌ Not installed${NC}"
         fi
 
         if [ $service_installed -eq 1 ]; then
             # Check if service is active
             if systemctl is-active --quiet "$service"; then
-                echo -e "${GREEN}[PASS] ${service} is running${NC}"
+                echo -e "${GREEN}[PASS] 🟢 Running${NC}"
             else
-                echo -e "${BLUE}${BOLD}[INFO] ${service} is not running${NC}"
+                echo -e "${BLUE}${BOLD}[INFO] 🔴 Not running${NC}"
             fi
 
             # Check if service is enabled
             if systemctl is-enabled --quiet "$service"; then
-                echo -e "${GREEN}[PASS] ${service} is enabled${NC}"
+                echo -e "${GREEN}[PASS] ⚡ Enabled${NC}"
             else
-                echo -e "${BLUE}${BOLD}[INFO] ${service} is not enabled, will not autostart at boot. To change, go to System Administration.${NC}"
+                echo -e "${BLUE}${BOLD}[INFO] ⚠️ Not enabled, will not autostart at boot. To change, go to System Administration.${NC}"
             fi
         fi
     done


### PR DESCRIPTION
## Description
This PR improves the visual display of service status checks in the node checker by:
- Adding intuitive emojis for different service states
- Improving visual separation between services
- Adding clear headers for each service
- Maintaining consistent color coding

## Changes
- Added emojis for service states (📥 installed, 🟢 running, ⚡ enabled)
- Added service headers with package emoji (📦)
- Added visual separators between services
- Improved status messages for better readability

## Service states
📥 for installed
❌ for not installed
🟢 for running
🔴 for not running
⚡ for enabled
⚠️ for not enabled

## Screenshot
The new output format looks like this:
![image](https://github.com/user-attachments/assets/1e9a5aed-c722-4241-b1d1-ca985146ea14)
