### PR TITLE
client-stats check already latest release

### DIFF
--- a/plugins/client-stats/plugin_client_stats.sh
+++ b/plugins/client-stats/plugin_client_stats.sh
@@ -47,7 +47,10 @@ function downloadClient(){
 # Upgrade function
 function upgrade(){
   getLatestVersion
-  if whiptail --title "Update $APP_NAME" --yesno "Installed Version is: $(cat $PLUGIN_INSTALL_PATH/current_version)\nLatest Version is:    $TAG\n\nReminder: Always read the release notes for breaking changes: $GITHUB_RELEASE_NODES\n\nDo you want to update to $TAG?" 12 78; then
+  VERSION=$(cat $PLUGIN_INSTALL_PATH/current_version)
+  # Remove front v if present and compare versions
+  [[ "${VERSION#v}" == "${TAG#v}" ]] && whiptail --title "Already updated" --msgbox "You are already on the latest version: $VERSION" 10 78 && return
+  if whiptail --title "Update $APP_NAME" --yesno "Installed Version is: $VERSION\nLatest Version is:    $TAG\n\nReminder: Always read the release notes for breaking changes: $GITHUB_RELEASE_NODES\n\nDo you want to update to $TAG?" 12 78; then
       sudo systemctl stop $SERVICE_NAME
       downloadClient
       sudo systemctl start $SERVICE_NAME


### PR DESCRIPTION
# Client-Stats Plugin Update

## Changes
- Added version comparison check in the upgrade function to prevent unnecessary update prompts
- Improved user experience by showing a clear message when already on the latest version
- Added version normalization by removing leading 'v' prefix before comparison

## Technical Details
- The upgrade function now compares the installed version with the latest version before prompting for an update
- If versions match, displays a simple message: "You are already on the latest version: [version]"
- Only shows the update prompt if a newer version is available
- Maintains all existing functionality while adding this new check

## Testing
The changes have been tested to ensure:
- Correct version comparison with and without 'v' prefix
- Proper display of "already updated" message
- Update prompt only shows when a newer version is available
- Existing update functionality works as expected when a new version is available