### PR TITLE
fix(install_2fa): additional config checks

### DIFF
--- a/helpers/install_2fa.sh
+++ b/helpers/install_2fa.sh
@@ -70,6 +70,24 @@ UsePAM yes
 AuthenticationMethods publickey,keyboard-interactive
 EOF
 
+    # Check if Include directive is present and not commented out
+    if grep -q "^#Include /etc/ssh/sshd_config.d/\*.conf" /etc/ssh/sshd_config; then
+        echo "❌ Include directive is commented out in /etc/ssh/sshd_config"
+        echo "✏️  Uncommenting Include directive..."
+        sudo sed -i 's|^#Include /etc/ssh/sshd_config.d/\*.conf|Include /etc/ssh/sshd_config.d/*.conf|' /etc/ssh/sshd_config
+    elif ! grep -q "^Include /etc/ssh/sshd_config.d/\*.conf" /etc/ssh/sshd_config; then
+        echo "❌ Required Include directive not found in /etc/ssh/sshd_config"
+        echo "✏️  Adding Include directive..."
+        echo "Include /etc/ssh/sshd_config.d/*.conf" | sudo tee -a /etc/ssh/sshd_config
+    fi
+    
+    # Check if KbdInteractiveAuthentication is not set to no
+    if grep -q "^KbdInteractiveAuthentication.*no" /etc/ssh/sshd_config; then
+        echo "❌ KbdInteractiveAuthentication is set to 'no' in /etc/ssh/sshd_config"
+        echo "🪛 Enabling KbdInteractiveAuthentication..."
+        sudo sed -i 's/^KbdInteractiveAuthentication.*no/KbdInteractiveAuthentication yes/' /etc/ssh/sshd_config
+    fi
+
     check_ssh_config
 
     echo "🔄 Restarting SSH service..."

--- a/helpers/install_2fa.sh
+++ b/helpers/install_2fa.sh
@@ -81,13 +81,14 @@ EOF
         echo "Include /etc/ssh/sshd_config.d/*.conf" | sudo tee -a /etc/ssh/sshd_config
     fi
     
-    # Check if KbdInteractiveAuthentication is not set to no
-    if grep -q "^KbdInteractiveAuthentication.*no" /etc/ssh/sshd_config; then
-        echo "❌ KbdInteractiveAuthentication is set to 'no' in /etc/ssh/sshd_config"
-        echo "🪛 Enabling KbdInteractiveAuthentication..."
-        sudo sed -i 's/^KbdInteractiveAuthentication.*no/KbdInteractiveAuthentication yes/' /etc/ssh/sshd_config
+    # Ensure KbdInteractiveAuthentication is explicitly enabled
+    if grep -qE "^[[:space:]]*#?[[:space:]]*KbdInteractiveAuthentication" /etc/ssh/sshd_config; then
+        echo "🪛 Normalizing KbdInteractiveAuthentication to 'yes' in /etc/ssh/sshd_config"
+        sudo sed -ri 's|^[[:space:]]*#?[[:space:]]*KbdInteractiveAuthentication.*|KbdInteractiveAuthentication yes|' /etc/ssh/sshd_config
+    else
+        echo "🪛 Adding KbdInteractiveAuthentication yes to /etc/ssh/sshd_config"
+        echo "KbdInteractiveAuthentication yes" | sudo tee -a /etc/ssh/sshd_config
     fi
-
     check_ssh_config
 
     echo "🔄 Restarting SSH service..."


### PR DESCRIPTION
# fix(2fa): Improve SSH configuration validation and handling

## Changes
- Added validation for required SSH configuration directives during 2FA installation
- Improved handling of commented Include directives by uncommenting them instead of adding duplicates
- Added check for KbdInteractiveAuthentication to ensure it's not disabled

## Technical Details
- Added check for `Include /etc/ssh/sshd_config.d/*.conf` directive
  - Now properly handles both commented and missing directives
  - Uses `sed` with pipe delimiter to avoid path escaping issues
- Added check for `KbdInteractiveAuthentication` to ensure it's not set to "no"
- Configuration checks only run during installation, not uninstallation
- Maintains existing error handling and user feedback patterns

## Testing
- Verified that commented Include directives are properly uncommented
- Confirmed that missing Include directives are added when needed
- Tested that KbdInteractiveAuthentication is properly enabled
- Validated that uninstall process remains unchanged

## Security Impact
These changes ensure that all necessary SSH configuration is properly set up for 2FA to work correctly, preventing potential authentication issues while maintaining security best practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the SSH 2FA installation process by ensuring necessary SSH configuration directives are present and correctly set, enhancing reliability and compatibility during setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->