### PR TITLE
chore(reth): enable ufw discv5 port

### DIFF
--- a/ethpillar.sh
+++ b/ethpillar.sh
@@ -985,6 +985,7 @@ while true; do
         sudo ufw allow 9000 comment 'Allow consensus client port'
         getClient
         [[ $CL == "Lighthouse" ]] && sudo ufw allow 9001/udp comment 'Allow consensus client QUIC port'
+        [[ $EL == "Reth" ]] && sudo ufw allow 30304/udp comment 'Allow execution client discv5 port'
         sudo ufw enable
         sudo ufw status numbered
         ohai "UFW firewall enabled."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - UDP traffic on port 30304 is now automatically allowed when enabling the firewall if the execution client is set to "Reth".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->