### PR TITLE
chore: change eth-educators to ethstaker

### DIFF
--- a/manage_validator_keys.sh
+++ b/manage_validator_keys.sh
@@ -46,7 +46,7 @@ function downloadEthstakerDepositCli(){
     sudo apt install jq curl -y
 
     #Setup variables
-    BINARIES_URL="https://github.com/eth-educators/ethstaker-deposit-cli/releases/download/v${edc_version}/ethstaker_deposit-cli-${edc_hash}-${_platform}-${_arch}.tar.gz"
+    BINARIES_URL="https://github.com/ethstaker/ethstaker-deposit-cli/releases/download/v${edc_version}/ethstaker_deposit-cli-${edc_hash}-${_platform}-${_arch}.tar.gz"
     BINARY_FILE="ethstaker_deposit-cli.tar.gz"
 
     ohai "Downloading URL: $BINARIES_URL"


### PR DESCRIPTION
ref: https://github.com/ethstaker/ethstaker-deposit-cli/pull/365

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the download source for the deposit CLI to use the official ethstaker repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->