### PR TITLE
chore(validator_keys): update ephemery to reuse Hoodi CSM values

### DIFF
--- a/manage_validator_keys.sh
+++ b/manage_validator_keys.sh
@@ -272,9 +272,10 @@ function setConfig(){
             EXPLORER="https://hoodi.cloud.blockscout.com"
           ;;
           ephemery)
+            # Reuse HOODI values unless ephemery-specific ones exist
             LAUNCHPAD_URL="https://launchpad.ephemery.dev"
-            LAUNCHPAD_URL_LIDO=${LAUNCHPAD_URL_LIDO_HOLESKY}
-            CSM_WITHDRAWAL_ADDRESS=${CSM_WITHDRAWAL_ADDRESS_HOLESKY}
+            LAUNCHPAD_URL_LIDO=${LAUNCHPAD_URL_LIDO_HOODI}
+            CSM_WITHDRAWAL_ADDRESS=${CSM_WITHDRAWAL_ADDRESS_HOODI}
             CSM_SENTINEL_URL="https://t.me/CSMSentinelTBD"
             FAUCET="https://faucet.bordel.wtf"
             HOMEPAGE="https://ephemery.dev"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Corrected Ephemery network configuration to reuse Hoodi-specific settings, ensuring the Lido launchpad URL and CSM withdrawal address resolve to the expected values.
  * Improves reliability when managing validator keys on Ephemery by aligning addresses with the intended network profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->