### PR TITLE
feat(docker): implement rootless docker with wrapper and bridge netwo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,15 @@ Already a running a Validator? EthPillar is compatible with [a Coincashew V2 Sta
   * Support for **AMD64 and ARM64** architecture
   * Recommend at least 16GB RAM for **ARM64** sbc
 
+  ### Rootless Docker
+
+  If you plan to run Docker in rootless mode, note:
+
+  - Some plugins previously used host networking which rootless Docker does not support. Those plugin compose files and run commands have been updated to use a user-defined bridge network named `ethpillar_default` and explicit `ports:` mappings where possible.
+  - After installing Docker rootless, create the network once on the host: `docker network create ethpillar_default`.
+  - If a plugin still requires host networking you will see a warning; converting those plugins to be fully rootless may require per-plugin changes.
+
+
 ## :triangular\_ruler: Option 1: Automated One-Liner Install
 
 Open a terminal window from anywhere by typing `Ctrl+Alt+T`

--- a/helpers/docker_wrapper.sh
+++ b/helpers/docker_wrapper.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Helpers to run docker commands in rootful or rootless environments.
+set -euo pipefail
+
+# Determine docker command prefix and whether sudo is required.
+# Exported variables:
+#  DOCKER_CMD - full docker command (e.g. "docker" or "sudo docker")
+#  DOCKER_COMPOSE_CMD - compose subcommand invocation (e.g. "docker compose" or "docker compose")
+
+_detect_docker_mode() {
+  # If docker command exists
+  if ! command -v docker >/dev/null 2>&1; then
+    return 1
+  fi
+
+  # Try docker info Rootless field first
+  if docker info --format '{{.Rootless}}' >/dev/null 2>&1; then
+    rootless=$(docker info --format '{{.Rootless}}' 2>/dev/null || echo "false")
+    if [[ "$rootless" == "true" ]]; then
+      DOCKER_CMD="docker"
+      DOCKER_COMPOSE_CMD="docker compose"
+      return 0
+    fi
+  fi
+
+  # If systemctl docker is active, assume rootful daemon and require sudo for non-root users
+  if systemctl is-active --quiet docker 2>/dev/null; then
+    if [[ $(id -u) -ne 0 ]]; then
+      DOCKER_CMD="sudo docker"
+      DOCKER_COMPOSE_CMD="sudo docker compose"
+    else
+      DOCKER_CMD="docker"
+      DOCKER_COMPOSE_CMD="docker compose"
+    fi
+    return 0
+  fi
+
+  # Fallback: if dockerd-rootless is running (systemd --user), assume rootless
+  if pgrep -f dockerd-rootless >/dev/null 2>&1; then
+    DOCKER_CMD="docker"
+    DOCKER_COMPOSE_CMD="docker compose"
+    return 0
+  fi
+
+  # Default to sudo docker for safety
+  if [[ $(id -u) -ne 0 ]]; then
+    DOCKER_CMD="sudo docker"
+    DOCKER_COMPOSE_CMD="sudo docker compose"
+  else
+    DOCKER_CMD="docker"
+    DOCKER_COMPOSE_CMD="docker compose"
+  fi
+  return 0
+}
+
+_detect_docker_mode
+
+export DOCKER_CMD
+export DOCKER_COMPOSE_CMD
+
+run_docker() { # run_docker <args...>
+  eval "$DOCKER_CMD" "$@"
+}
+
+run_compose() { # run_compose <compose-args...>
+  eval "$DOCKER_COMPOSE_CMD" "$@"
+}
+
+# Verify docker mode and ethpillar_default network reachability.
+_docker_verify_network() {
+  echo "🔎 Docker detection: checking mode and network 'ethpillar_default'..."
+
+  # Determine rootless vs system using docker info, fallback to pgrep checks
+  local mode="unknown"
+  if ${DOCKER_CMD} info --format '{{.Rootless}}' >/dev/null 2>&1; then
+    local rl=$(${DOCKER_CMD} info --format '{{.Rootless}}' 2>/dev/null || echo "false")
+    if [[ "$rl" == "true" ]]; then
+      mode="rootless"
+    else
+      mode="system"
+    fi
+  else
+    if pgrep -f dockerd-rootless >/dev/null 2>&1; then
+      mode="rootless"
+    else
+      mode="system"
+    fi
+  fi
+
+  echo "  - Docker mode: ${mode}"
+
+  # Check network existence
+  if ${DOCKER_CMD} network inspect ethpillar_default >/dev/null 2>&1; then
+    echo "  - Network 'ethpillar_default': exists"
+  else
+    echo "  - Network 'ethpillar_default': NOT FOUND"
+    echo "    You can create it with: ${DOCKER_CMD} network create ethpillar_default"
+    return 0
+  fi
+
+  # Test reachability by running a short-lived container attached to the network.
+  # Use alpine and immediately exit after ensuring it can be created on the network.
+  local test_name="ethpillar_net_test_$$"
+  if ${DOCKER_CMD} run --rm --network ethpillar_default --name ${test_name} alpine:3.18 true >/dev/null 2>&1; then
+    echo "  - Network usability: OK (ephemeral container started on 'ethpillar_default')"
+  else
+    echo "  - Network usability: FAILED (could not start container on 'ethpillar_default')"
+    echo "    If you're running rootless Docker, ensure your user has the required permissions and that the Docker rootless socket is available:"
+    echo "      export DOCKER_HOST=unix://\$XDG_RUNTIME_DIR/docker.sock"
+  fi
+}
+
+# Run verification when sourced interactively or by scripts to surface useful hints.
+_docker_verify_network

--- a/helpers/install_docker.sh
+++ b/helpers/install_docker.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
+
+ROOTLESS=${ROOTLESS:-false}
 
 echo "🔄 Updating and upgrading all system packages..."
 sudo apt update -y && sudo apt upgrade -y
@@ -8,26 +10,50 @@ sudo apt update -y && sudo apt upgrade -y
 echo "🧹 Removing old or conflicting Docker packages..."
 for pkg in docker.io docker-doc docker-compose docker-compose-v2 podman-docker containerd runc; do sudo apt-get remove -y $pkg; done
 
-echo "🔑 Adding Docker’s official GPG key..."
-sudo install -m 0755 -d /etc/apt/keyrings
-sudo apt-get install -y ca-certificates curl gnupg
-source /etc/os-release
-curl -fsSL https://download.docker.com/linux/${ID}/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-sudo chmod a+r /etc/apt/keyrings/docker.gpg
+if [[ "$ROOTLESS" == "true" ]]; then
+  echo "🐳 Installing Docker (rootless mode)..."
+  sudo apt-get install -y uidmap dbus-user-session
+  # Follow Docker rootless install script
+  curl -fsSL https://get.docker.com/rootless | sh
+  echo "💡 To use rootless docker, add the following to your shell profile if not present:"
+  echo "    export PATH=\"$HOME/bin:$PATH\""
+  echo "    export DOCKER_HOST=unix://$XDG_RUNTIME_DIR/docker.sock"
+  echo "🎉 Rootless Docker installed. Start a new shell to pick up PATH changes."
+else
+  echo "🔑 Adding Docker’s official GPG key..."
+  sudo install -m 0755 -d /etc/apt/keyrings
+  sudo apt-get install -y ca-certificates curl gnupg
+  source /etc/os-release
+  curl -fsSL https://download.docker.com/linux/${ID}/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+  sudo chmod a+r /etc/apt/keyrings/docker.gpg
 
-echo "📚 Adding Docker’s official repository..."
-echo \
-  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/${ID} \
-  ${VERSION_CODENAME} stable" | \
-  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-echo "🔄 Updating and upgrading all system packages again (with Docker repo)..."
-sudo apt update -y && sudo apt upgrade -y
+  echo "📚 Adding Docker’s official repository..."
+  echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/${ID} \
+    ${VERSION_CODENAME} stable" | \
+    sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+  echo "🔄 Updating and upgrading all system packages again (with Docker repo)..."
+  sudo apt update -y && sudo apt upgrade -y
 
-echo "🐳 Installing Docker Engine, CLI, containerd, Buildx, and Compose plugin..."
-sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+  echo "🐳 Installing Docker Engine, CLI, containerd, Buildx, and Compose plugin..."
+  sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
-echo "🚦 Enabling and starting Docker service..."
-sudo systemctl enable docker
-sudo systemctl restart docker
+  echo "🚦 Enabling and starting Docker service..."
+  sudo systemctl enable docker
+  sudo systemctl restart docker
 
-echo "🎉 Docker and Docker Compose are fully installed and up to date!"
+  echo "🎉 Docker and Docker Compose are fully installed and up to date!"
+fi
+
+# Create a user bridge network used by EthPillar plugins (idempotent).
+echo "🌐 Ensuring docker network 'ethpillar_default' exists..."
+# Prefer the user's docker command if rootless; fall back to sudo for system Docker
+if command -v docker >/dev/null 2>&1; then
+  DOCKER_CMD=docker
+else
+  DOCKER_CMD="sudo docker"
+fi
+
+# Try to inspect the network; create if missing. Use the DOCKER_CMD so this works for rootless and system installs.
+${DOCKER_CMD} network inspect ethpillar_default >/dev/null 2>&1 || ${DOCKER_CMD} network create ethpillar_default >/dev/null
+echo "✅ Network 'ethpillar_default' is ready."

--- a/plugins/aztec/ROOTLESS.md
+++ b/plugins/aztec/ROOTLESS.md
@@ -1,0 +1,17 @@
+Aztec plugin: Rootless Docker guidance
+
+This compose example has been updated to be compatible with rootless Docker:
+
+- `network_mode: host` was replaced with a user-defined bridge network `ethpillar_default` and explicit `ports:` mappings.
+- Rootless Docker does not support host networking. If you previously relied on host networking, ensure the plugin's required ports are exposed in the `ports:` section.
+
+Notes:
+- Default ports in the example: P2P (TCP/UDP) `40400`, HTTP/API `8080`.
+- If you run Docker rootless, ensure the container can bind to the host ports. Rootless Docker maps container ports to user-owned ports; if a port is <1024 you may need to choose a higher port.
+- The compose file now defines a `ethpillar_default` bridge network. You can create it manually if needed:
+
+  docker network create ethpillar_default
+
+- For full compatibility, review any plugins that still use `--net=host` or `network_mode: host` and adjust accordingly.
+
+If you want help converting the plugin to a true rootless deployment (removing any remaining host-network-only features), open an issue with details about which features rely on host networking.

--- a/plugins/aztec/docker-compose.yml.example
+++ b/plugins/aztec/docker-compose.yml.example
@@ -17,9 +17,15 @@ services:
       SEQ_PUBLISHER_PRIVATE_KEY: ${SEQ_PUBLISHER_PRIVATE_KEY:-}
     entrypoint: >
       sh -c 'node --no-warnings /usr/src/yarn-project/aztec/dest/bin/index.js start --node --archiver --sequencer'
-      - ${P2P_PORT:-40400}:40400/tcp
-      - ${P2P_PORT:-40400}:40400/udp
-      - ${PORT:-8080}:8080
+    ports:
+      - "${P2P_PORT:-40400}:40400/tcp"
+      - "${P2P_PORT:-40400}:40400/udp"
+      - "${PORT:-8080}:8080"
     volumes:
       -  /opt/ethpillar/aztec/data:/data
-    network_mode: host
+    networks:
+      - ethpillar_default
+
+networks:
+  ethpillar_default:
+    driver: bridge

--- a/plugins/aztec/plugin_aztec.sh
+++ b/plugins/aztec/plugin_aztec.sh
@@ -10,6 +10,12 @@ set -euo pipefail
 
 SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+# Source docker wrapper for rootless/rootful compatibility
+if [[ -f /opt/ethpillar/helpers/docker_wrapper.sh ]]; then
+  # shellcheck disable=SC1091
+  source /opt/ethpillar/helpers/docker_wrapper.sh
+fi
+
 # Variables
 RELEASE_URL="https://api.github.com/repos/AztecProtocol/aztec-packages/releases/latest"
 DESCRIPTION="🥷 Aztec Sequencer Node: a privacy first L2 on Ethereum by Aztec Labs"
@@ -247,10 +253,10 @@ whiptail --title "$APP_NAME: Install Complete" --msgbox "$MSG_COMPLETE" 28 78
 # Uninstall
 function removeAll() {
   if whiptail --title "Uninstall $APP_NAME" --defaultno --yesno "Are you sure you want to remove $APP_NAME" 9 78; then
-    cd $PLUGIN_INSTALL_PATH 2>/dev/null && docker compose down || true
-    sudo docker rm -f $APP_NAME 2>/dev/null || true
-    TAG=$(grep "DOCKER_TAG" $PLUGIN_INSTALL_PATH/.env | sed "s/^DOCKER_TAG=\(.*\)/\1/")
-    sudo docker rmi -f $DOCKER_IMAGE:"$TAG"
+  cd $PLUGIN_INSTALL_PATH 2>/dev/null && ${DOCKER_COMPOSE_CMD} down || true
+  ${DOCKER_CMD} rm -f $APP_NAME 2>/dev/null || true
+  TAG=$(grep "DOCKER_TAG" $PLUGIN_INSTALL_PATH/.env | sed "s/^DOCKER_TAG=\(.*\)/\1/")
+  ${DOCKER_CMD} rmi -f $DOCKER_IMAGE:"$TAG"
     if [[ -f "$PLUGIN_INSTALL_PATH/.cast_installed_by_plugin" && -f /usr/local/bin/cast ]]; then
       sudo rm /usr/local/bin/cast
     fi

--- a/plugins/sentinel/README.md
+++ b/plugins/sentinel/README.md
@@ -1,0 +1,12 @@
+CSM Sentinel plugin - Rootless Docker Notes
+
+The sentinel run command was adjusted to avoid `--net=host` so it works under rootless Docker. Changes made:
+
+- `--net=host` removed; container now runs on `ethpillar_default` network and uses mapped ports where appropriate.
+- Ensure the network exists before running any containers:
+
+  docker network create ethpillar_default
+
+- If the sentinel requires specific ports to be reachable from the host, add `-p HOSTPORT:CONTAINERPORT` options when running the container or update the compose file if you prefer compose.
+
+If you encounter issues with networking or discovery while running rootless, please report the specific service and ports, and we can propose more targeted changes.

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -29,10 +29,15 @@ function uninstallPlugins(){
 		sudo rm -rf /opt/ethpillar/plugin-csm
 	fi
 	if [[ -d /opt/ethpillar/plugin-sentinel ]]; then
-		sudo docker stop csm-sentinel
-		sudo docker rm csm-sentinel
-		sudo docker rmi csm-sentinel
-		sudo docker volume rm csm-sentinel-persistent
+		# Use docker wrapper if available
+		if [[ -f /opt/ethpillar/helpers/docker_wrapper.sh ]]; then
+		  # shellcheck disable=SC1091
+		  source /opt/ethpillar/helpers/docker_wrapper.sh
+		fi
+		${DOCKER_CMD} stop csm-sentinel || true
+		${DOCKER_CMD} rm csm-sentinel || true
+		${DOCKER_CMD} rmi csm-sentinel || true
+		${DOCKER_CMD} volume rm csm-sentinel-persistent || true
 		sudo rm -rf /opt/ethpillar/plugin-sentinel
 	fi
 	if [[ -d /opt/ethpillar/plugin-dora ]]; then
@@ -57,10 +62,14 @@ function uninstallPlugins(){
 		sudo rm -rf /opt/ethpillar/plugin-contributoor
 	fi
 	if [[ -d /opt/ethpillar/aztec ]]; then
-	    cd /opt/ethpillar/aztec 2>/dev/null && docker compose down || true
-	    sudo docker rm -f aztec-sequencer
+	    if [[ -f /opt/ethpillar/helpers/docker_wrapper.sh ]]; then
+	      # shellcheck disable=SC1091
+	      source /opt/ethpillar/helpers/docker_wrapper.sh
+	    fi
+	    cd /opt/ethpillar/aztec 2>/dev/null && ${DOCKER_COMPOSE_CMD} down || true
+	    ${DOCKER_CMD} rm -f aztec-sequencer || true
 	    TAG=$(grep "DOCKER_TAG" /opt/ethpillar/aztec/.env | sed "s/^DOCKER_TAG=\(.*\)/\1/")
-	    sudo docker rmi -f aztecprotocol/aztec:"$TAG"
+	    ${DOCKER_CMD} rmi -f aztecprotocol/aztec:"$TAG" || true
 	    if [[ -f /opt/ethpillar/aztec/.cast_installed_by_plugin && -f /usr/local/bin/cast ]]; then
 	      sudo rm /usr/local/bin/cast
 	    fi

--- a/view_logs.sh
+++ b/view_logs.sh
@@ -21,6 +21,12 @@ if ! command -v ccze &> /dev/null; then
    sudo apt-get install ccze -y
 fi
 
+# Source docker wrapper for rootless/rootful compatibility
+if [[ -f /opt/ethpillar/helpers/docker_wrapper.sh ]]; then
+   # shellcheck disable=SC1091
+   source /opt/ethpillar/helpers/docker_wrapper.sh
+fi
+
 # Check if the current user belongs to the systemd-journal group
 current_user=$(whoami)
 group_members=$(getent group systemd-journal | cut -d: -f2-)
@@ -52,8 +58,8 @@ cols=$(tput cols)
 
 # Aztec node with remote rpc
 if [[ -d /opt/ethpillar/aztec ]] && [[ ! -f /etc/systemd/system/consensus.service ]]; then
-      tmux new-session -d -s logs \; \
-           send-keys 'cd  /opt/ethpillar/aztec && sudo docker compose logs -fn 233' C-m \; \
+    tmux new-session -d -s logs \; \
+       send-keys 'cd  /opt/ethpillar/aztec && ${DOCKER_COMPOSE_CMD} logs -fn 233' C-m \; \
            split-window -h \; \
            select-pane -t 1 \; \
            send-keys 'btop --utf-force' C-m \; \
@@ -67,7 +73,7 @@ elif [[ -d /opt/ethpillar/aztec ]] && [[ -f /etc/systemd/system/consensus.servic
            split-window -h \; \
            send-keys 'btop --utf-force' C-m \; \
            split-window -v \; \
-           send-keys 'cd  /opt/ethpillar/aztec && sudo docker compose logs -fn 233' C-m \; \
+           send-keys 'cd  /opt/ethpillar/aztec && ${DOCKER_COMPOSE_CMD} logs -fn 233' C-m \; \
            select-pane -t 0 \; \
            split-window -v \; \
            send-keys 'journalctl -fu execution --no-hostname | ccze -A' C-m \;


### PR DESCRIPTION
…rking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Rootless Docker support via an auto-detecting Docker wrapper; unified DOCKER_CMD/DOCKER_COMPOSE_CMD.
  - Automatic creation/verification of the ethpillar_default bridge network.
  - Installer supports rootless or system Docker paths and prepares required network.

- Documentation
  - Added Rootless Docker guidance in prerequisites.
  - Updated Aztec and Sentinel docs with bridge networking, port mapping, and rootless notes.

- Refactor
  - Replaced hardcoded docker/compose calls with wrapper variables across core, Aztec, Sentinel, uninstall, and log scripts.
  - Aztec compose example removes host networking, adds ports and ethpillar_default network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->