### PR TITLE
feat(aztec): add syncproof, status endpoint healthchecks, align ports…

### DIFF
--- a/plugins/aztec/.env.example
+++ b/plugins/aztec/.env.example
@@ -12,7 +12,7 @@ P2P_IP=
 P2P_PORT=40400
 
 #Port to run the Aztec Services on
-PORT=8080
+AZTEC_PORT=8080
 
 #The private key to be used by the publisher.
 #SEQ_PUBLISHER_PRIVATE_KEY=

--- a/plugins/aztec/docker-compose.yml.example
+++ b/plugins/aztec/docker-compose.yml.example
@@ -23,22 +23,15 @@ services:
       COINBASE: ${COINBASE}
       P2P_IP: ${P2P_IP:-}
       P2P_PORT: ${P2P_PORT}
-      PORT: ${PORT}
+      AZTEC_PORT: ${AZTEC_PORT}
       LOG_LEVEL: ${LOG_LEVEL:-info}
       SEQ_PUBLISHER_PRIVATE_KEY: ${SEQ_PUBLISHER_PRIVATE_KEY:-}
     entrypoint: >
       sh -c 'node --no-warnings /usr/src/yarn-project/aztec/dest/bin/index.js start --node --archiver --sequencer'
     ports:
-      - target: ${PORT:-8080}
-        published: ${PORT:-8080}
-        protocol: tcp
-        host_ip: 127.0.0.1
-      - target: ${P2P_PORT:-40400}
-        published: ${P2P_PORT:-40400}
-        protocol: tcp
-      - target: ${P2P_PORT:-40400}
-        published: ${P2P_PORT:-40400}
-        protocol: udp
+      - ${AZTEC_PORT}:${AZTEC_PORT}
+      - ${P2P_PORT}:${P2P_PORT}
+      - ${P2P_PORT}:${P2P_PORT}/udp
     volumes:
       -  /opt/ethpillar/aztec/data:/data
     logging:


### PR DESCRIPTION
… to latest docs, fix L1 rpc urls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added local status check endpoint and sync proof generation to health checks.

- Chores
  - Standardized port environment variable to AZTEC_PORT across configuration.
  - Simplified Docker port mappings; use direct host-to-container bindings for HTTP and P2P (TCP/UDP); removed host IP constraints.
  - Normalized default RPC URLs from host.docker.internal to localhost and trimmed multi-value entries to the first.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->