### PR TITLE
Fix mev-boost version parsing to correctly detect full semver (e.g., v1.10.1)

### DIFF
--- a/ethpillar.sh
+++ b/ethpillar.sh
@@ -670,7 +670,7 @@ while true; do
         test -f /etc/systemd/system/consensus.service && _CL=$(curl -s -X GET "${API_BN_ENDPOINT}/eth/v1/node/version" -H "accept: application/json" | jq -r '.data.version')
         test -f /etc/systemd/system/execution.service && _EL=$(curl -s -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"web3_clientVersion","params":[],"id":2}' "${EL_RPC_ENDPOINT}" | jq -r '.result')
         [[ $EL == "Erigon-Caplin" ]] && _CL=$(curl -s -X GET "${API_BN_ENDPOINT}/eth/v1/node/version" -H "accept: application/json" | jq -r '.data.version')
-        _MB=$(if [[ -f /etc/systemd/system/mevboost.service ]]; then printf "Mev-boost: $(mev-boost --version 2>&1 | sed 's/.*\s\([0-9]*\.[0-9]*\).*/\1/')"; else printf "Mev-boost: Not Installed"; fi)
+        _MB=$(if [[ -f /etc/systemd/system/mevboost.service ]]; then printf "Mev-boost: $(mev-boost --version 2>&1 | sed -E 's/.*([0-9]+\.[0-9]+\.[0-9]+).*/\1/')"; else printf "Mev-boost: Not Installed"; fi)
         if [[ -z $_CL ]] ; then
           _CL="Not installed or still starting up."
         fi

--- a/update_mevboost.sh
+++ b/update_mevboost.sh
@@ -22,7 +22,7 @@ function getCurrentVersion(){
     #Find version in format #.#.#
     if [[ $INSTALLED ]] ; then
         # shellcheck disable=SC2001
-        VERSION=$(echo "$INSTALLED" | sed 's/.*\s\([0-9]*\.[0-9]*\).*/\1/')
+        VERSION=$(echo "$INSTALLED" | sed -E 's/.*([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
 	else
 		VERSION="Client not installed."
 	fi
@@ -82,7 +82,7 @@ function promptViewLogs(){
 function getLatestVersion(){
     TAG_URL="https://api.github.com/repos/flashbots/mev-boost/releases/latest"
 	#Get tag name and remove leading 'v'
-	TAG=$(curl -s $TAG_URL | jq -r .tag_name | sed 's/.*v\([0-9]*\.[0-9]*\).*/\1/')
+	TAG=$(curl -s $TAG_URL | jq -r .tag_name | sed -E 's/.*([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
 	# Exit in case of null tag
 	[[ -z $TAG ]] || [[ $TAG == "null"  ]] && echo "ERROR: Couldn't find the latest version tag" && exit 1
 	CHANGES_URL="https://github.com/flashbots/mev-boost/releases"


### PR DESCRIPTION
**Summary**
This PR fixes two related issues where mev-boost versions were being parsed incorrectly, causing the script to treat v1.10.1 as v1.10. As a result, EthPillar would not recognize the true latest mev-boost release, and the “View software versions” screen displayed incomplete version information.

**What was fixed**
update_mevboost.sh
Updated the version extraction logic to correctly parse full semantic versions (major.minor.patch).
This ensures the updater detects new releases such as v1.10.1 instead of truncating to 1.10.
ethpillar.sh

Updated the version parsing in the “View software versions” section so the installed mev-boost version is shown with the full patch version (e.g., 1.10.1).

**Why this fix is needed**
The previous regex only captured major.minor, which caused:
Incorrect detection of the latest release.
Incorrect display of the installed version.
Prevented proper update prompts when a new patch version was released.

**Testing**
Verified that both installed and latest versions correctly detect full semver format.
Confirmed the update workflow now correctly identifies v1.10.1 as the latest version.

**Notes**
This improves reliability of mev-boost update handling and ensures version reporting is accurate for all future semver releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated MEV-Boost version detection to correctly parse three-part semantic version numbers instead of two-part versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->