### PR TITLE
Unbound _VC crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,28 @@
 
 ---
 
+## Switching to this fork for updates!
+
+This is a fork of CoinCashew's excellent staking tool at https://github.com/coincashew/ethpillar.  
+We haven't heard from CoinCashew for a while, so we are making updates and bug fixes here.
+
+To get the updates from this repo you'll need to do the following only once:
+
+After installing EthPillar normally, run these two commands:
+
+```bash
+cd ~/git/ethpillar
+git remote set-url origin https://github.com/mjkeating/EthPillar.git
+```
+
+Then, from EthPillar run **System Administration → Update EthPillar** and it will pull the latest from this repo.
+
+Hopefully, we'll see CoinCashew return soon!
+
+**Note:** This fork is now at version **5.2.5** with fixes for Nethermind, and MEV-Boost updating.
+
+---
+
 ## 🚀 What is EthPillar?
 
 EthPillar is a free, open-source tool to set up and manage your Ethereum node with just a few commands. Whether you’re home solo staking, using Lido CSM, defending cypherpunk ethos with Aztec L2 sequencer node, or running your own RPC node, EthPillar makes everything easy—from installing clients to monitoring your system—all via a friendly text user interface (TUI).

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 ## Switching to this fork for updates!
 
 This is a fork of CoinCashew's excellent staking tool at https://github.com/coincashew/ethpillar.  
-We haven't heard from CoinCashew for a while, so we are making updates and bug fixes here.
+We haven't heard from CoinCashew for a while, so this is a place where fixes and updates can be made.
 
 To get the updates from this repo you'll need to do the following only once:
 
@@ -29,7 +29,7 @@ cd ~/git/ethpillar
 git remote set-url origin https://github.com/mjkeating/EthPillar.git
 ```
 
-Then, from EthPillar run **System Administration → Update EthPillar** and it will update from this repo.
+After this, from EthPillar you can run **System Administration → Update EthPillar** and it will update from this repo.
 
 Hopefully, we'll see CoinCashew return soon!
 

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ We haven't heard from CoinCashew for a while, so we are making updates and bug f
 
 To get the updates from this repo you'll need to do the following only once:
 
-After installing EthPillar normally, run these two commands:
+After installing EthPillar normally (see below) or if you have an existing install, run these two commands:
 
 ```bash
 cd ~/git/ethpillar
 git remote set-url origin https://github.com/mjkeating/EthPillar.git
 ```
 
-Then, from EthPillar run **System Administration → Update EthPillar** and it will pull the latest from this repo.
+Then, from EthPillar run **System Administration → Update EthPillar** and it will update from this repo.
 
 Hopefully, we'll see CoinCashew return soon!
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ After this, from EthPillar you can run **System Administration → Update EthPil
 
 Hopefully, we'll see CoinCashew return soon!
 
-**Note:** This fork is now at version **5.2.5** with fixes for Nethermind, and MEV-Boost updating.
+**Note:** This fork is now at version **5.2.6** - includes fixes for Nethermind and MEV-Boost updating. Also, Improved versions display.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ After this, from EthPillar you can run **System Administration → Update EthPil
 
 Hopefully, we'll see CoinCashew return soon!
 
-**Note:** This fork is now at version **5.2.6** - includes fixes for Nethermind and MEV-Boost updating. Also, Improved versions display.
+**Note:** This fork is now at version **5.2.6** - it includes fixes for Nethermind and MEV-Boost updating. Also, improved versions display.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ After this, from EthPillar you can run **System Administration → Update EthPil
 
 Hopefully, we'll see CoinCashew return soon!
 
-**Note:** This fork is now at version **5.2.6** - it includes fixes for Nethermind and MEV-Boost updating. Also, improved versions display.
+**Note:** This fork is now at version **5.2.7** - it includes fixes for Nethermind and MEV-Boost updating. Also, improved versions display.
 
 ---
 

--- a/ethpillar.sh
+++ b/ethpillar.sh
@@ -670,7 +670,8 @@ while true; do
         test -f /etc/systemd/system/consensus.service && _CL=$(curl -s -X GET "${API_BN_ENDPOINT}/eth/v1/node/version" -H "accept: application/json" | jq -r '.data.version')
         test -f /etc/systemd/system/execution.service && _EL=$(curl -s -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"web3_clientVersion","params":[],"id":2}' "${EL_RPC_ENDPOINT}" | jq -r '.result')
         [[ $EL == "Erigon-Caplin" ]] && _CL=$(curl -s -X GET "${API_BN_ENDPOINT}/eth/v1/node/version" -H "accept: application/json" | jq -r '.data.version')
-        _MB=$(if [[ -f /etc/systemd/system/mevboost.service ]]; then printf "Mev-boost: $(mev-boost --version 2>&1 | sed 's/.*\s\([0-9]*\.[0-9]*\).*/\1/')"; else printf "Mev-boost: Not Installed"; fi)
+        #_MB=$(if [[ -f /etc/systemd/system/mevboost.service ]]; then printf "Mev-boost: $(mev-boost --version 2>&1 | sed 's/.*\s\([0-9]*\.[0-9]*\).*/\1/')"; else printf "Mev-boost: Not Installed"; fi)
+        _MB=$(if [[ -f /etc/systemd/system/mevboost.service ]]; then printf "Mev-boost: %s" "$(mev-boost --version 2>&1 | sed -E 's/.*v?([0-9]+\.[0-9]+\.[0-9]+).*/\1/' || echo 'unknown')"; else printf "Mev-boost: Not Installed"; fi)
         if [[ -z "${_VC:-}" ]] ; then
           _VC="Validator client: Not installed."
         fi

--- a/ethpillar.sh
+++ b/ethpillar.sh
@@ -666,17 +666,31 @@ while true; do
         if whiptail --title "Shutdown" --defaultno --yesno "Are you sure you want to shutdown?" 8 78; then sudo shutdown now; fi
         ;;
       📦)
-        test -f /etc/systemd/system/validator.service && getClient && getCurrentVersion && _VC="Validator client: $CLIENT $VERSION"
-        test -f /etc/systemd/system/consensus.service && _CL=$(curl -s -X GET "${API_BN_ENDPOINT}/eth/v1/node/version" -H "accept: application/json" | jq -r '.data.version')
-        test -f /etc/systemd/system/execution.service && _EL=$(curl -s -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"web3_clientVersion","params":[],"id":2}' "${EL_RPC_ENDPOINT}" | jq -r '.result')
-        [[ $EL == "Erigon-Caplin" ]] && _CL=$(curl -s -X GET "${API_BN_ENDPOINT}/eth/v1/node/version" -H "accept: application/json" | jq -r '.data.version')
-        _MB=$(if [[ -f /etc/systemd/system/mevboost.service ]]; then printf "Mev-boost: $(mev-boost --version 2>&1 | sed 's/.*\s\([0-9]*\.[0-9]*\).*/\1/')"; else printf "Mev-boost: Not Installed"; fi)
-        if [[ -z $_CL ]] ; then
+        # Use conditional assignments similar to _MB to avoid unbound-variable crashes
+        if [[ -f /etc/systemd/system/validator.service ]]; then
+          getClient && getCurrentVersion && _VC="Validator client: $CLIENT $VERSION"
+        else
+          _VC="Validator client: Not Installed"
+        fi
+
+        if [[ -f /etc/systemd/system/consensus.service ]]; then
+          _CL=$(curl -s -X GET "${API_BN_ENDPOINT}/eth/v1/node/version" -H "accept: application/json" | jq -r '.data.version')
+          [[ -z "${_CL}" ]] && _CL="Not installed or still starting up."
+        else
           _CL="Not installed or still starting up."
         fi
-        if [[ -z $_EL ]] ; then
+
+        if [[ -f /etc/systemd/system/execution.service ]]; then
+          _EL=$(curl -s -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"web3_clientVersion","params":[],"id":2}' "${EL_RPC_ENDPOINT}" | jq -r '.result')
+          [[ -z "${_EL}" ]] && _EL="Not installed or still starting up."
+        else
           _EL="Not installed or still starting up."
         fi
+
+        [[ $EL == "Erigon-Caplin" ]] && _CL=$(curl -s -X GET "${API_BN_ENDPOINT}/eth/v1/node/version" -H "accept: application/json" | jq -r '.data.version')
+
+        _MB=$(if [[ -f /etc/systemd/system/mevboost.service ]]; then printf "Mev-boost: $(mev-boost --version 2>&1 | sed 's/.*\s\([0-9]*\.[0-9]*\).*/\1/')"; else printf "Mev-boost: Not Installed"; fi)
+
         whiptail --title "Installed versions" --msgbox "Consensus client: ${_CL}\nExecution client: ${_EL}\n${_VC}\n${_MB}\nEthPillar: $EP_VERSION" 12 78
         ;;
       📊)

--- a/ethpillar.sh
+++ b/ethpillar.sh
@@ -12,7 +12,7 @@
 # 🙌 Ask questions on Discord:
 #    * https://discord.gg/dEpAVWgFNB
 
-EP_VERSION="5.2.4"
+EP_VERSION="5.2.5"
 
 # Default text editor
 export EDITOR="nano"

--- a/ethpillar.sh
+++ b/ethpillar.sh
@@ -671,13 +671,13 @@ while true; do
         test -f /etc/systemd/system/execution.service && _EL=$(curl -s -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"web3_clientVersion","params":[],"id":2}' "${EL_RPC_ENDPOINT}" | jq -r '.result')
         [[ $EL == "Erigon-Caplin" ]] && _CL=$(curl -s -X GET "${API_BN_ENDPOINT}/eth/v1/node/version" -H "accept: application/json" | jq -r '.data.version')
         _MB=$(if [[ -f /etc/systemd/system/mevboost.service ]]; then printf "Mev-boost: $(mev-boost --version 2>&1 | sed 's/.*\s\([0-9]*\.[0-9]*\).*/\1/')"; else printf "Mev-boost: Not Installed"; fi)
-        if [[ -z "${_VC}" ]] ; then
+        if [[ -z "${_VC:-}" ]] ; then
           _VC="Validator client: Not installed."
         fi
-        if [[ -z $_CL ]] ; then
+        if [[ -z "${_CL:-}" ]] ; then
           _CL="Not installed or still starting up."
         fi
-        if [[ -z $_EL ]] ; then
+        if [[ -z "${_EL:-}" ]] ; then
           _EL="Not installed or still starting up."
         fi
         whiptail --title "Installed versions" --msgbox "Consensus client: ${_CL}\nExecution client: ${_EL}\n${_VC}\n${_MB}\nEthPillar: $EP_VERSION" 12 78

--- a/ethpillar.sh
+++ b/ethpillar.sh
@@ -12,7 +12,7 @@
 # 🙌 Ask questions on Discord:
 #    * https://discord.gg/dEpAVWgFNB
 
-EP_VERSION="5.2.5"
+EP_VERSION="5.2.6"
 
 # Default text editor
 export EDITOR="nano"

--- a/ethpillar.sh
+++ b/ethpillar.sh
@@ -12,7 +12,7 @@
 # 🙌 Ask questions on Discord:
 #    * https://discord.gg/dEpAVWgFNB
 
-EP_VERSION="5.2.6"
+EP_VERSION="5.2.7"
 
 # Default text editor
 export EDITOR="nano"

--- a/update_execution.sh
+++ b/update_execution.sh
@@ -148,19 +148,6 @@ function updateClient(){
 	fi
 	case $EL in
 	  Nethermind)
-		# [[ "${_arch}" == "amd64" ]] && _architecture="x64" || _architecture="arm64"
-		# RELEASE_URL="https://api.github.com/repos/NethermindEth/nethermind/$_URL_SUFFIX"
-		# BINARIES_URL=$(curl -s "$RELEASE_URL" | jq -r ".assets[] | select(.name) | .browser_download_url" | grep --ignore-case "${_platform}"-"${_architecture}")
-		# info "✅ Downloading URL: $BINARIES_URL"
-		# cd "$HOME" || true
-		# wget -O nethermind.zip "$BINARIES_URL" || error "❌ Unable to wget file"
-		# unzip -o nethermind.zip -d "$HOME"/nethermind || error "❌ Unable to unzip file"
-		# rm nethermind.zip
-		# sudo systemctl stop execution
-		# sudo rm -rf /usr/local/bin/nethermind
-		# sudo mv "$HOME"/nethermind /usr/local/bin/nethermind || error "❌ Unable to move file"
-		# sudo systemctl start execution
-	    # ;;
 		[[ "${_arch}" == "amd64" ]] && _architecture="x64" || _architecture="arm64"
 
 		# Force lowercase platform (important!)

--- a/update_mevboost.sh
+++ b/update_mevboost.sh
@@ -21,8 +21,9 @@ function getCurrentVersion(){
     INSTALLED=$(mev-boost --version 2>&1)  # capture stderr too, just in case
     if [[ -n $INSTALLED ]] ; then
         # shellcheck disable=SC2001
-        # Extract major.minor.patch, optional leading 'v', ignore any suffix/commit info
-        VERSION=$(echo "$INSTALLED" | sed 's/.*v\?\([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/')
+		# Extract major.minor or major.minor.patch, optional leading 'v', ignore suffix/commit info
+		# Patch part is optional to handle versions like 1.11 (no patch)
+		VERSION=$(echo "$INSTALLED" | sed 's/.*v\?\([0-9]\+\.[0-9]\+\(\.[0-9]\+\)\?\).*/\1/')
         # Fallback if sed fails or no match
         if [[ -z $VERSION || $VERSION == "$INSTALLED" ]]; then
             VERSION="unknown"


### PR DESCRIPTION
In "Failover Staking Node" mode there is no validator client.  In this mode, when you try to view the software versions you get the following crash:
/usr/local/bin/ethpillar: line 680: _VC: unbound variable
This PR fixes this by adding a missing check that _VC is set, and if not setting the value to 'Validator client: Not Installed'
<img width="811" height="301" alt="ethpillar_fallback_sw_versions_fixed_Screenshot 2025-11-24 133528" src="https://github.com/user-attachments/assets/3b1dc462-1048-42f3-aa36-842157f9f502" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better handling and default messages when validator/execution/consensus components or MEV-Boost are missing or still starting.
  * More robust version detection and safer empty-variable checks.

* **Chores**
  * Improved update/download flow with clearer errors and safer archive handling.

* **Documentation**
  * Added instructions for switching to this fork and updating from it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->